### PR TITLE
Fixed an issue with recent NodeJS versions

### DIFF
--- a/cpp/winnus.cpp
+++ b/cpp/winnus.cpp
@@ -580,7 +580,7 @@ void WINNUS_Read(const FunctionCallbackInfo<Value>& args) {
 
   args.GetReturnValue().Set(
     String::NewFromOneByte(isolate,
-      (const uint8_t *)data->data, String::kNormalString, data->len));
+      (const uint8_t *)data->data, v8::NewStringType::kNormal, data->len).ToLocalChecked());
 }
 
 void WINNUS_Disconnect(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
While trying to compile it for the Espruino WebIDE, I noticed that it failed. While I'm not an expert with native code integration in NodeJS, it's probably due to recent incompatibilities with the underlying V8.

Although it now compiles, I could not test it so far.